### PR TITLE
Add accessible Flutter app for exhibition

### DIFF
--- a/exposicao_acessivel/.gitignore
+++ b/exposicao_acessivel/.gitignore
@@ -1,0 +1,27 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub-cache/
+build/
+coverage/
+flutter_*.png
+.generated/
+.melos_tool/
+# IntelliJ related
+.idea/
+*.iml
+*.ipr
+*.iws
+# Visual Studio Code related
+.vscode/
+# macOS
+.DS_Store
+# Android/Gradle
+.gradle/
+/local.properties
+**/GeneratedPluginRegistrant.java
+# iOS
+**/Flutter/Generated.xcconfig
+**/Runner/GeneratedPluginRegistrant.*
+# Web
+**/generated_plugin_registrant.dart

--- a/exposicao_acessivel/README.md
+++ b/exposicao_acessivel/README.md
@@ -1,0 +1,20 @@
+# Exposição Acessível — Vozes do Tempo
+
+Aplicativo Flutter com foco em acessibilidade digital para visitantes de uma exposição. A tela inicial reúne um vídeo de boas-vindas com interpretação em Libras e narração, além de atalhos para o texto curatorial e para a área de audiodescrições.
+
+## Recursos principais
+
+- Reprodução automática de vídeo acessível (Libras e áudio) na tela inicial.
+- Botões com rótulos descritivos para acesso rápido ao texto curatorial e às audiodescrições.
+- Tela com texto curatorial formatado para leitura confortável e suporte a leitores de tela.
+- Tela de audiodescrições com campo numérico para o painel, feedback falado e visual, e lista das faixas disponíveis.
+- Utilização de `Semantics`, mensagens faladas (`SemanticsService`) e componentes com alto contraste para garantir acessibilidade.
+
+## Como executar
+
+1. Instale o [Flutter](https://docs.flutter.dev/get-started/install) (SDK 3.10 ou superior).
+2. No terminal, acesse esta pasta (`exposicao_acessivel`).
+3. Execute `flutter pub get` para instalar as dependências.
+4. Inicie o aplicativo com `flutter run` em um emulador ou dispositivo físico.
+
+Os áudios e o vídeo utilizados são exemplos hospedados publicamente e podem ser substituídos por arquivos próprios da exposição.

--- a/exposicao_acessivel/analysis_options.yaml
+++ b/exposicao_acessivel/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    avoid_print: true

--- a/exposicao_acessivel/lib/data/audio_descriptions.dart
+++ b/exposicao_acessivel/lib/data/audio_descriptions.dart
@@ -1,0 +1,46 @@
+class AudioDescription {
+  const AudioDescription({
+    required this.panelNumber,
+    required this.title,
+    required this.summary,
+    required this.audioUrl,
+  });
+
+  final String panelNumber;
+  final String title;
+  final String summary;
+  final String audioUrl;
+}
+
+/// Lista de audiodescrições disponíveis. Os arquivos de áudio são
+/// hospedados publicamente apenas para fins de demonstração.
+const List<AudioDescription> kAudioDescriptions = [
+  AudioDescription(
+    panelNumber: '1',
+    title: 'Boas-vindas e apresentação da curadoria',
+    summary:
+        'Introdução ao conceito da exposição e às pessoas responsáveis pela curadoria.',
+    audioUrl:
+        'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+  ),
+  AudioDescription(
+    panelNumber: '2',
+    title: 'Painel 2 — Paisagens sensoriais',
+    summary:
+        'Descrição das cores predominantes, texturas e elementos táteis do segundo painel.',
+    audioUrl:
+        'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
+  ),
+  AudioDescription(
+    panelNumber: '3',
+    title: 'Painel 3 — Trajetórias de artistas',
+    summary:
+        'Contextualização histórica das obras e biografias das pessoas artistas participantes.',
+    audioUrl:
+        'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3',
+  ),
+];
+
+Map<String, AudioDescription> buildAudioDescriptionIndex() {
+  return {for (final item in kAudioDescriptions) item.panelNumber: item};
+}

--- a/exposicao_acessivel/lib/main.dart
+++ b/exposicao_acessivel/lib/main.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+import 'screens/home_screen.dart';
+import 'theme/app_theme.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const ExpoAccessApp());
+}
+
+class ExpoAccessApp extends StatelessWidget {
+  const ExpoAccessApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Exposição Acessível',
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.lightTheme,
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('pt', 'BR'),
+      ],
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/exposicao_acessivel/lib/screens/audio_description_screen.dart
+++ b/exposicao_acessivel/lib/screens/audio_description_screen.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../data/audio_descriptions.dart';
+
+class AudioDescriptionScreen extends StatefulWidget {
+  const AudioDescriptionScreen({super.key});
+
+  @override
+  State<AudioDescriptionScreen> createState() =>
+      _AudioDescriptionScreenState();
+}
+
+class _AudioDescriptionScreenState extends State<AudioDescriptionScreen> {
+  final TextEditingController _panelController = TextEditingController();
+  final FocusNode _panelFocusNode = FocusNode(debugLabel: 'panelInput');
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  final Map<String, AudioDescription> _descriptionIndex =
+      buildAudioDescriptionIndex();
+
+  StreamSubscription<PlayerState>? _playerStateSubscription;
+  String? _currentPanel;
+  PlayerState _playerState = PlayerState.stopped;
+
+  @override
+  void initState() {
+    super.initState();
+    _playerStateSubscription =
+        _audioPlayer.onPlayerStateChanged.listen((PlayerState state) {
+      setState(() {
+        _playerState = state;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _playerStateSubscription?.cancel();
+    _panelController.dispose();
+    _panelFocusNode.dispose();
+    _audioPlayer.dispose();
+    super.dispose();
+  }
+
+  Future<void> _announce(BuildContext context, String message) async {
+    await SemanticsService.announce(
+      message,
+      Directionality.of(context),
+    );
+  }
+
+  Future<void> _playRequestedDescription() async {
+    final context = this.context;
+    final panelNumber = _panelController.text.trim();
+
+    if (panelNumber.isEmpty) {
+      await _announce(context, 'Informe o número do painel para ouvir a descrição.');
+      _panelFocusNode.requestFocus();
+      return;
+    }
+
+    final description = _descriptionIndex[panelNumber];
+    if (description == null) {
+      await _audioPlayer.stop();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Não encontramos audiodescrição para o painel $panelNumber.'),
+        ),
+      );
+      await _announce(context, 'Não encontramos audiodescrição para o painel $panelNumber.');
+      return;
+    }
+
+    await _audioPlayer.stop();
+    await _audioPlayer.play(UrlSource(description.audioUrl));
+    setState(() {
+      _currentPanel = panelNumber;
+    });
+
+    if (!mounted) return;
+    final playingMessage =
+        'Reproduzindo audiodescrição do painel ${description.panelNumber}: ${description.title}.';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(playingMessage)),
+    );
+    await _announce(context, playingMessage);
+  }
+
+  Future<void> _stopPlayback() async {
+    await _audioPlayer.stop();
+    setState(() {
+      _playerState = PlayerState.stopped;
+    });
+    if (!mounted) return;
+    await _announce(context, 'Reprodução de áudio interrompida.');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Audiodescrições'),
+        actions: [
+          if (_playerState == PlayerState.playing)
+            IconButton(
+              onPressed: _stopPlayback,
+              tooltip: 'Parar reprodução',
+              icon: const Icon(Icons.stop_circle),
+            ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Digite o número do painel e pressione confirmar para ouvir a audiodescrição correspondente.',
+                style: theme.textTheme.bodyLarge,
+              ),
+              const SizedBox(height: 20),
+              Semantics(
+                container: true,
+                child: TextField(
+                  controller: _panelController,
+                  focusNode: _panelFocusNode,
+                  keyboardType: TextInputType.number,
+                  textInputAction: TextInputAction.done,
+                  decoration: const InputDecoration(
+                    labelText: 'Número do painel',
+                    helperText: 'Utilize apenas números. Exemplo: 1, 2 ou 3.',
+                  ),
+                  onSubmitted: (_) => _playRequestedDescription(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Semantics(
+                button: true,
+                hint: 'Inicia a audiodescrição do painel informado no campo anterior.',
+                child: ElevatedButton.icon(
+                  onPressed: _playRequestedDescription,
+                  icon: const Icon(Icons.play_circle_fill),
+                  label: const Text('Confirmar e ouvir'),
+                ),
+              ),
+              const SizedBox(height: 24),
+              if (_currentPanel != null)
+                Semantics(
+                  liveRegion: true,
+                  label: 'Audiodescrição em reprodução',
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.secondaryContainer,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      'Painel $_currentPanel em reprodução',
+                      style: theme.textTheme.labelLarge,
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: Semantics(
+                  label: 'Lista de painéis com audiodescrição disponível',
+                  explicitChildNodes: true,
+                  child: ListView.separated(
+                    itemCount: kAudioDescriptions.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final description = kAudioDescriptions[index];
+                      final isCurrent = description.panelNumber == _currentPanel;
+                      return ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: theme.colorScheme.primaryContainer,
+                          foregroundColor: theme.colorScheme.onPrimaryContainer,
+                          child: Text(description.panelNumber),
+                        ),
+                        title: Text(description.title),
+                        subtitle: Text(description.summary),
+                        trailing: Icon(
+                          isCurrent ? Icons.volume_up : Icons.play_arrow,
+                          color: isCurrent
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.onSurfaceVariant,
+                        ),
+                        onTap: () {
+                          _panelController.text = description.panelNumber;
+                          _playRequestedDescription();
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/exposicao_acessivel/lib/screens/curatorial_text_screen.dart
+++ b/exposicao_acessivel/lib/screens/curatorial_text_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class CuratorialTextScreen extends StatelessWidget {
+  const CuratorialTextScreen({super.key});
+
+  static const List<String> _paragraphs = [
+    'A exposição "Vozes do Tempo" apresenta narrativas visuais e sonoras '
+        'sobre memórias coletivas. As obras reunidas exploram a relação '
+        'entre passado e futuro a partir de experiências sensoriais.',
+    'Cada sala conta com peças táteis, descrições sonoras e recursos visuais '
+        'pensados para acolher diferentes corpos e modos de percepção. '
+        'O público é convidado a caminhar em seu próprio ritmo, descobrindo '
+        'novas camadas de significado em cada parada.',
+    'A curadoria reforça o compromisso com a acessibilidade cultural. '
+        'Além do conteúdo multimídia, a equipe educativa preparou oficinas '
+        'e visitas mediadas que ampliam as possibilidades de interação com '
+        'as obras expostas.',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Texto curatorial'),
+      ),
+      body: SafeArea(
+        child: Semantics(
+          container: true,
+          explicitChildNodes: true,
+          child: ListView.separated(
+            padding: const EdgeInsets.all(24),
+            itemBuilder: (context, index) {
+              final paragraph = _paragraphs[index];
+              return Semantics(
+                readOnly: true,
+                child: SelectableText(
+                  paragraph,
+                  textAlign: TextAlign.justify,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              );
+            },
+            separatorBuilder: (_, __) => const SizedBox(height: 24),
+            itemCount: _paragraphs.length,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/exposicao_acessivel/lib/screens/home_screen.dart
+++ b/exposicao_acessivel/lib/screens/home_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/welcome_video_player.dart';
+import 'audio_description_screen.dart';
+import 'curatorial_text_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  void _openCuratorialText(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const CuratorialTextScreen(),
+      ),
+    );
+  }
+
+  void _openAudioDescriptions(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const AudioDescriptionScreen(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Exposição Acessível — Vozes do Tempo'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Semantics(
+                header: true,
+                child: Text(
+                  'Vozes do Tempo',
+                  style: theme.textTheme.displaySmall,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Bem-vindo! Assista ao vídeo com Libras e áudio de orientação '
+                'para saber como aproveitar todos os recursos de acessibilidade.',
+                style: theme.textTheme.bodyLarge,
+              ),
+              const SizedBox(height: 24),
+              const WelcomeVideoPlayer(
+                videoUrl:
+                    'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+                semanticsLabel:
+                    'Vídeo introdutório em Libras com narração em áudio.',
+                semanticsHint:
+                    'Reproduz automaticamente ao abrir a exposição. Toque no botão para pausar ou retomar.',
+              ),
+              const SizedBox(height: 32),
+              Semantics(
+                label: 'Acesso rápido às seções da exposição',
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: () => _openCuratorialText(context),
+                      icon: const Icon(Icons.menu_book),
+                      label: const Text('Ler texto curatorial'),
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton.icon(
+                      onPressed: () => _openAudioDescriptions(context),
+                      icon: const Icon(Icons.record_voice_over),
+                      label: const Text('Ouvir audiodescrições'),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 40),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Semantics(
+                    explicitChildNodes: true,
+                    label: 'Informações de acessibilidade',
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Text(
+                          'Recursos inclusivos',
+                          style: TextStyle(
+                            fontWeight: FontWeight.w700,
+                            fontSize: 18,
+                          ),
+                        ),
+                        SizedBox(height: 8),
+                        Text(
+                          '• Vídeo com interpretação em Libras e narração em áudio.\n'
+                          '• Descrições em áudio para cada painel da exposição.\n'
+                          '• Conteúdo textual com contraste adequado e compatível com leitores de tela.',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/exposicao_acessivel/lib/theme/app_theme.dart
+++ b/exposicao_acessivel/lib/theme/app_theme.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  const AppTheme._();
+
+  static ThemeData get lightTheme {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: const Color(0xFF00695C),
+      brightness: Brightness.light,
+    );
+
+    return ThemeData(
+      colorScheme: colorScheme,
+      useMaterial3: true,
+      textTheme: const TextTheme(
+        displaySmall: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 26,
+          letterSpacing: 0.5,
+        ),
+        bodyLarge: TextStyle(fontSize: 16, height: 1.5),
+        bodyMedium: TextStyle(fontSize: 15, height: 1.4),
+        labelLarge: TextStyle(
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          foregroundColor: Colors.white,
+          backgroundColor: colorScheme.primary,
+          minimumSize: const Size.fromHeight(56),
+          textStyle: const TextStyle(fontSize: 18),
+        ),
+      ),
+      inputDecorationTheme: const InputDecorationTheme(
+        border: OutlineInputBorder(),
+        labelStyle: TextStyle(fontSize: 18),
+        helperMaxLines: 3,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: colorScheme.primary,
+        contentTextStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+        ),
+      ),
+    );
+  }
+}

--- a/exposicao_acessivel/lib/widgets/welcome_video_player.dart
+++ b/exposicao_acessivel/lib/widgets/welcome_video_player.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class WelcomeVideoPlayer extends StatefulWidget {
+  const WelcomeVideoPlayer({
+    super.key,
+    required this.videoUrl,
+    required this.semanticsLabel,
+    required this.semanticsHint,
+    this.autoplay = true,
+    this.loop = true,
+  });
+
+  final String videoUrl;
+  final String semanticsLabel;
+  final String semanticsHint;
+  final bool autoplay;
+  final bool loop;
+
+  @override
+  State<WelcomeVideoPlayer> createState() => _WelcomeVideoPlayerState();
+}
+
+class _WelcomeVideoPlayerState extends State<WelcomeVideoPlayer> {
+  late final VideoPlayerController _controller;
+  bool _isReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = VideoPlayerController.networkUrl(Uri.parse(widget.videoUrl))
+      ..setLooping(widget.loop)
+      ..setVolume(1.0)
+      ..initialize().then((_) {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _isReady = true;
+        });
+        if (widget.autoplay) {
+          _controller.play();
+        }
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _togglePlayback() {
+    if (!_isReady) return;
+    if (_controller.value.isPlaying) {
+      _controller.pause();
+    } else {
+      _controller.play();
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final aspectRatio = _isReady ? _controller.value.aspectRatio : 16 / 9;
+
+    return Semantics(
+      container: true,
+      label: widget.semanticsLabel,
+      hint: widget.semanticsHint,
+      explicitChildNodes: true,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: Stack(
+          alignment: Alignment.bottomCenter,
+          children: [
+            AspectRatio(
+              aspectRatio: aspectRatio,
+              child: _isReady
+                  ? VideoPlayer(_controller)
+                  : Container(
+                      color: Colors.black,
+                      alignment: Alignment.center,
+                      child: const CircularProgressIndicator(),
+                    ),
+            ),
+            if (_isReady)
+              Positioned(
+                bottom: 8,
+                right: 8,
+                child: Semantics(
+                  button: true,
+                  value: _controller.value.isPlaying
+                      ? 'Reproduzindo'
+                      : 'Pausado',
+                  hint: _controller.value.isPlaying
+                      ? 'Toque para pausar o vídeo de boas-vindas.'
+                      : 'Toque para retomar o vídeo de boas-vindas.',
+                  child: FloatingActionButton.extended(
+                    heroTag: 'toggleVideo',
+                    onPressed: _togglePlayback,
+                    backgroundColor: theme.colorScheme.primary,
+                    foregroundColor: theme.colorScheme.onPrimary,
+                    label: Text(
+                      _controller.value.isPlaying ? 'Pausar' : 'Reproduzir',
+                    ),
+                    icon: Icon(
+                      _controller.value.isPlaying
+                          ? Icons.pause
+                          : Icons.play_arrow,
+                    ),
+                  ),
+                ),
+              ),
+            if (_isReady)
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Semantics(
+                  label: 'Barra de progresso do vídeo de boas-vindas',
+                  slider: true,
+                  child: VideoProgressIndicator(
+                    _controller,
+                    allowScrubbing: true,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 16,
+                    ),
+                    colors: VideoProgressColors(
+                      playedColor: theme.colorScheme.primary,
+                      bufferedColor: theme.colorScheme.primaryContainer,
+                      backgroundColor: theme.colorScheme.surfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/exposicao_acessivel/pubspec.yaml
+++ b/exposicao_acessivel/pubspec.yaml
@@ -1,0 +1,24 @@
+name: exposicao_acessivel
+description: Aplicativo Flutter acessível para audiodescrições e textos curatoriais de uma exposição.
+publish_to: "none"
+version: 1.0.0+1
+
+environment:
+  sdk: ">=3.1.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  video_player: ^2.7.0
+  audioplayers: ^5.2.0
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.3
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a new Flutter project focused on an accessible exhibition experience
- implement home, curatorial text, and audio description screens with semantics and media playback
- configure theming, sample audiovisual data, and documentation for running the app

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca191b58a083239fe9edecdcf232ee